### PR TITLE
Explicit return type for the client

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,16 +12,18 @@ interface GetConfigArgs {
   access_token: string,
   refresh_token: string,
   realm_id: string,
-  max_timeout_in_ms?: number
+  max_timeout_in_ms?: number,
+  fetchFn: typeof fetch
 }
 export const getConfig = async ({
   use_sandbox,
   access_token,
   refresh_token,
   realm_id,
-  max_timeout_in_ms
+  max_timeout_in_ms,
+  fetchFn
 }: GetConfigArgs): Promise<Config> => ({
-  ...await discovery({ use_sandbox: use_sandbox }),
+  ...await discovery({ fetchFn, use_sandbox: use_sandbox }),
   REFRESH_TOKEN: refresh_token as string | null,
   ACCESS_TOKEN: access_token as string | null,
   REALM_ID: realm_id as string | null,

--- a/src/discovery.ts
+++ b/src/discovery.ts
@@ -20,15 +20,17 @@ export interface DiscoveryConfig {
 }
 
 interface DiscoveryArgs {
-  use_sandbox: boolean
+  use_sandbox: boolean,
+  fetchFn: typeof fetch
 }
 export const discovery = async ({
-  use_sandbox
+  use_sandbox,
+  fetchFn
 }: DiscoveryArgs): Promise<DiscoveryConfig> => {
   const discoveryURL = !use_sandbox
     ? DISCOVERY_URL_LIVE
     : DISCOVERY_URL_SANDBOX;
-  const discoveryResponse = await fetch(discoveryURL, {
+  const discoveryResponse = await fetchFn(discoveryURL, {
     headers: {
       Accept: "application/json"
     }

--- a/src/list.ts
+++ b/src/list.ts
@@ -143,12 +143,15 @@ export const fetchListQuery = async <T extends QBOQueryableEntityType>({
 };
 
 interface ListInit {
+  initFetchFn: typeof fetch,
   config: Config
 }
 
 export interface ListArgs<T extends QBOQueryableEntityType> {
   entity: T,
-  opts?: QueryOptsBase<T>
+  opts?: QueryOptsBase<T>,
+  /** @desc A custom fetch function to use for this list request. This will override any fetchFn passed to the client. */
+  fetchFn?: typeof fetch
 }
 
 export type ListResponse<T extends QBOQueryableEntityType> = {
@@ -162,14 +165,17 @@ export type ListResponse<T extends QBOQueryableEntityType> = {
 };
 
 export const list = ({
+  initFetchFn = fetch,
   config
 }: ListInit) => async <T extends QBOQueryableEntityType>({
   entity,
-  opts
+  opts,
+  fetchFn: _fetchFn
 }: ListArgs<T>): Promise<GetQBOQueryableEntityType<T>[]> => {
   if (!isQueryableEntity(entity)) {
     throw new Error(`Invalid entity: ${entity}`);
   }
+  const fetchFn = _fetchFn ?? initFetchFn;
 
   const Entity = snakeCaseToCamelCase(entity);
 
@@ -188,7 +194,7 @@ export const list = ({
       "Authorization": tokenAuth({ config }),
       "Accept": "application/json"
     },
-    fetchFn: fetch
+    fetchFn: fetchFn
   });
 
   return data?.QueryResponse[Entity] ?? [];

--- a/src/query.unit.test.ts
+++ b/src/query.unit.test.ts
@@ -259,6 +259,7 @@ describe("fetchQuery", () => {
 
     const headers = { "Content-Type": "application/json" };
 
+    // @ts-ignore
     const fetchFn: any = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       expect(url).toBe("https://localhost.com/apirealm_id/query?limit=10&offset=0&query=select%20*%20from%20Employee%20where%20BirthDate%20%3D%20%272022-03-10%27&minorversion=65");
@@ -295,6 +296,7 @@ describe("fetchQuery", () => {
 
     const headers = { "Content-Type": "application/json" };
 
+    // @ts-ignore
     const fetchFn: any = jest.fn((input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
       expect(url).toBe("https://localhost.com/apirealm_id/query?limit=10&offset=0&query=select%20*%20from%20Employee%20where%20BirthDate%20%3D%20%272022-03-10%27&minorversion=65");

--- a/src/report.ts
+++ b/src/report.ts
@@ -38,22 +38,29 @@ export const createReportOpts = <T extends QBOReportEntityType>({
 };
 
 interface ReportInit {
-  config: Config
+  config: Config,
+  initFetchFn: typeof fetch
 }
 export interface ReportArgs<T extends QBOReportEntityType> {
   entity: T,
-  opts?: ReportQuery<T>
+  opts?: ReportQuery<T>,
+  /** @desc A custom fetch function to use for this report request. This will override any fetchFn passed to the client. */
+  fetchFn?: typeof fetch
 }
 
+export type ReportResponse<T extends QBOReportEntityType> = EntitySpecificReport<T>;
 export const report = ({
-  config
+  config,
+  initFetchFn = fetch
 }: ReportInit) => async <T extends QBOReportEntityType>({
   entity,
-  opts
-}: ReportArgs<T>): Promise<EntitySpecificReport<T>> => {
+  opts,
+  fetchFn: _fetchFn
+}: ReportArgs<T>): Promise<ReportResponse<T>> => {
   if (!isReportEntity(entity)) {
     throw new Error(`Invalid entity: ${entity}`);
   }
+  const fetchFn = _fetchFn ?? initFetchFn;
 
   const queryParams = createReportOpts<T>({ opts });
 
@@ -63,7 +70,7 @@ export const report = ({
     query_params: queryParams
   });
 
-  return fetch(url, {
+  return fetchFn(url, {
     method: "GET",
     headers: {
       "User-Agent": "qbo-api",

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,6 @@ Key extends `${infer FirstPart}_${infer FirstLetter}${infer LastPart}`
   : Key
 >;
 
-export type DePromisify<T> = T extends Promise<infer U> ? U : never;
-
 export interface RefreshTokenResponse {
   x_refresh_token_expires_in: number,
   refresh_token:              string,

--- a/src/upsert.ts
+++ b/src/upsert.ts
@@ -17,22 +17,29 @@ export type QueryResponse<T extends QBOQueryableEntityType> = {
 };
 
 interface UpsertInit {
+  initFetchFn: typeof fetch,
   config: Config
 }
 export interface UpsertArgs<T extends QBOQueryableEntityType> {
   entity: T,
-  record: GetQBOQueryableEntityType<T>
+  record: GetQBOQueryableEntityType<T>,
+  /** @desc A custom fetch function to use for this upsert request. This will override any fetchFn passed to the client. */
+  fetchFn?: typeof fetch
 }
 
+export type UpsertResponse<T extends QBOQueryableEntityType> = GetQBOQueryableEntityType<T>;
 export const upsert = ({
+  initFetchFn = fetch,
   config
 }: UpsertInit) => async <T extends QBOQueryableEntityType>({
   entity,
-  record
-}: UpsertArgs<T>): Promise<GetQBOQueryableEntityType<T>> => {
+  record,
+  fetchFn: _fetchFn
+}: UpsertArgs<T>): Promise<UpsertResponse<T>> => {
   if (!isQueryableEntity(entity)) {
     throw new Error(`Invalid entity: ${entity}`);
   }
+  const fetchFn = _fetchFn ?? initFetchFn;
 
   const Entity = snakeCaseToCamelCase(entity);
   const url = makeRequestURL({
@@ -40,7 +47,7 @@ export const upsert = ({
     path: `/${Entity.toLowerCase()}`
   });
 
-  const data = await fetch(url, {
+  const data = await fetchFn(url, {
     method: "POST",
     headers: {
       "User-Agent": "qbo-api",


### PR DESCRIPTION
- Adding an explicit return type for the client, rather than relying on typeof like we were
- Adding ability to pass a custom fetch implementation to both the client (library-wide), and to individual client methods.
- Adding some comments to arguments in a few places to make things easier to understand