### PR TITLE
Explicitly defining client methods instead of relying on typeof

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbo",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "A client for interfacing with the QBO API.",
   "repository": "https://github.com/Client-Powered/qbo",
   "main": "lib/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbo",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "A client for interfacing with the QBO API.",
   "repository": "https://github.com/Client-Powered/qbo",
   "main": "lib/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,17 @@
-import { RefreshTokenResponse, Tokens } from "./types";
+import { QBOQueryableEntityType, QBOReportEntityType, RefreshTokenResponse, Tokens } from "./types";
 import { basicAuth, getJson, getSignalForTimeout, makeFormBody, recastAbortError } from "./utils";
 import { getConfig } from "./config";
-import { list } from "./list";
-import { upsert } from "./upsert";
-import { read } from "./read";
-import { report } from "./report";
+import { list, ListArgs, ListResponse } from "./list";
+import { upsert, UpsertArgs, UpsertResponse } from "./upsert";
+import { read, ReadArgs, ReadResponse } from "./read";
+import { report, ReportArgs, ReportResponse } from "./report";
 
+
+export type { Tokens, QBOQueryableEntityType, QBOReportEntityType, GetQBOQueryableEntityType, GetEntitySpecificReport } from "./types";
 export type { ReportArgs, ReportResponse } from "./report";
 export type { ReadArgs, ReadResponse } from "./read";
 export type { UpsertArgs, UpsertResponse } from "./upsert";
 export type { ListArgs, ListResponse } from "./list";
-export type { Tokens };
 
 export interface ClientArgs {
   client_id: string,
@@ -30,13 +31,32 @@ export interface QboClient {
   get tokens(): Tokens,
 
   /** @desc Read one QBO entity of a given type by id */
-  read: ReturnType<typeof read>,
+  read<T extends QBOQueryableEntityType>({
+    entity,
+    entity_id,
+    fetchFn
+  }: ReadArgs<T>): Promise<ReadResponse<T>>,
+
   /** @desc List QBO entities of a given type with optional query parameters */
-  list: ReturnType<typeof list>,
+  list<T extends QBOQueryableEntityType>({
+    entity,
+    opts,
+    fetchFn
+  }: ListArgs<T>): Promise<ListResponse<T>>,
+
   /** @desc Update if exists, otherwise insert one QBO entity of a given type */
-  upsert: ReturnType<typeof upsert>,
+  upsert<T extends QBOQueryableEntityType>({
+    entity,
+    record,
+    fetchFn
+  }: UpsertArgs<T>): Promise<UpsertResponse<T>>,
+
   /** @desc Query a QBO report of a given type with optional query parameters */
-  report: ReturnType<typeof report>
+  report<T extends QBOReportEntityType>({
+    entity,
+    opts,
+    fetchFn
+  }: ReportArgs<T>): Promise<ReportResponse<T>>
 }
 
 export const client = async ({

--- a/src/report.ts
+++ b/src/report.ts
@@ -1,4 +1,4 @@
-import { EntitySpecificReport, QBOReportEntityType } from "./types";
+import { GetEntitySpecificReport, QBOReportEntityType } from "./types";
 import { Config } from "./config";
 import {
   getJson,
@@ -48,7 +48,7 @@ export interface ReportArgs<T extends QBOReportEntityType> {
   fetchFn?: typeof fetch
 }
 
-export type ReportResponse<T extends QBOReportEntityType> = EntitySpecificReport<T>;
+export type ReportResponse<T extends QBOReportEntityType> = GetEntitySpecificReport<T>;
 export const report = ({
   config,
   initFetchFn = fetch
@@ -81,6 +81,6 @@ export const report = ({
     },
     signal: getSignalForTimeout({ config })
   })
-    .then(getJson<EntitySpecificReport<T>>())
+    .then(getJson<GetEntitySpecificReport<T>>())
     .catch(recastAbortError);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -84,6 +84,7 @@ export type QboQueryableEntityToType = {
   employee: EmployeeQboData
 };
 
+/** Gets the entity object type from the entity name  */
 export type GetQBOQueryableEntityType<T extends QBOQueryableEntityType> =
   T extends keyof QboQueryableEntityToType ? QboQueryableEntityToType[T] : {
     Id: string,
@@ -134,7 +135,8 @@ export type QBOReportEntityType = (typeof _reportEntityNames)[number];
 
 export const qboReportEntities: QBOReportEntityType[] = _reportEntityNames as any;
 
-export type EntitySpecificReport<T extends QBOReportEntityType> = Omit<NameReportTableTransactionsListColumnQboData, "Header"> & {
+/** Gets the report object type from the entity name  */
+export type GetEntitySpecificReport<T extends QBOReportEntityType> = Omit<NameReportTableTransactionsListColumnQboData, "Header"> & {
   Header: Omit<NameReportTableTransactionsListColumnQboData["Header"], "ReportName"> & {
     ReportName: SnakeToCamelCase<T>
   }


### PR DESCRIPTION
- Adding further comments for clarity
- Explicitly defining client methods instead of relying on typeof