### PR TITLE
Having the api methods return Result objects from `ts-error-as-value`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -34,7 +34,6 @@
   },
   "plugins": [
     "eslint-plugin-no-null",
-    "eslint-plugin-jsdoc",
     "@typescript-eslint"
   ],
   "rules": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qbo",
-  "version": "0.1.21",
+  "version": "0.2.0",
   "description": "A client for interfacing with the QBO API.",
   "repository": "https://github.com/Client-Powered/qbo",
   "main": "dist/index.js",
@@ -20,6 +20,7 @@
     "node": ">=16.0.0"
   },
   "dependencies": {
+    "ts-error-as-value": "^0.4.207",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
@@ -29,10 +30,11 @@
     "@babel/preset-typescript": "^7.10.1",
     "@babel/register": "^7.10.5",
     "@types/cors": "^2.8.12",
+    "@types/date-fns": "^2.6.0",
     "@types/express": "^4.17.13",
     "@types/jest": "^29.1.2",
     "@types/node": "^20.4.5",
-    "@types/node-fetch": "^2.5.7",
+    "@types/node-fetch": "^2.6.11",
     "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^5.39.0",
     "@typescript-eslint/parser": "^5.39.0",
@@ -40,7 +42,6 @@
     "dotenv": "^16.0.3",
     "eslint": "^8.25.0",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-no-null": "^1.0.2",
     "jest": "^29.2.0",
     "jest-junit": "^16.0.0",
@@ -49,5 +50,6 @@
     "ts-jest": "^29.0.3",
     "ts-node": "latest",
     "typescript": "latest"
-  }
+  },
+  "packageManager": "yarn@4.0.2"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import { QBOQueryableEntityType, QBOReportEntityType, RefreshTokenResponse, Tokens } from "./lib/types";
-import { basicAuth, getJson, getSignalForTimeout, makeFormBody, recastAbortError } from "./lib/utils";
+import { basicAuth, getJson, getSignalForTimeout, makeFormBody, handleQBOError } from "./lib/utils";
 import { getConfig } from "./lib/config";
 import { list, ListArgs, ListResponse } from "./list";
 import { upsert, UpsertArgs, UpsertResponse } from "./upsert";
 import { read, ReadArgs, ReadResponse } from "./read";
 import { report, ReportArgs, ReportResponse } from "./report";
+import "ts-error-as-value/lib/globals";
 
-
+export * as QBOError from "./lib/errors/error-classes";
 export type { Tokens, QBOQueryableEntityType, QBOReportEntityType, GetQBOQueryableEntityType, GetEntitySpecificReport } from "./lib/types";
 export type { ReportArgs, ReportResponse } from "./report";
 export type { ReadArgs, ReadResponse } from "./read";
@@ -26,8 +27,8 @@ export interface ClientArgs {
 }
 
 export interface QboClient {
-  refreshAccessToken(): Promise<void>,
-  revokeAccess(tokenType: "REFRESH" | "ACCESS"): Promise<void>,
+  refreshAccessToken(): Promise<Result>,
+  revokeAccess(tokenType: "REFRESH" | "ACCESS"): Promise<Result>,
   get tokens(): Tokens,
 
   /** @desc Read one QBO entity of a given type by id */
@@ -35,28 +36,28 @@ export interface QboClient {
     entity,
     entity_id,
     fetchFn
-  }: ReadArgs<T>): Promise<ReadResponse<T>>,
+  }: ReadArgs<T>): Promise<Result<ReadResponse<T>>>,
 
   /** @desc List QBO entities of a given type with optional query parameters */
   list<T extends QBOQueryableEntityType>({
     entity,
     opts,
     fetchFn
-  }: ListArgs<T>): Promise<ListResponse<T>>,
+  }: ListArgs<T>): Promise<Result<ListResponse<T>>>,
 
   /** @desc Update if exists, otherwise insert one QBO entity of a given type */
   upsert<T extends QBOQueryableEntityType>({
     entity,
     record,
     fetchFn
-  }: UpsertArgs<T>): Promise<UpsertResponse<T>>,
+  }: UpsertArgs<T>): Promise<Result<UpsertResponse<T>>>,
 
   /** @desc Query a QBO report of a given type with optional query parameters */
   report<T extends QBOReportEntityType>({
     entity,
     opts,
     fetchFn
-  }: ReportArgs<T>): Promise<ReportResponse<T>>
+  }: ReportArgs<T>): Promise<Result<ReportResponse<T>>>
 }
 
 export const client = async ({
@@ -69,7 +70,9 @@ export const client = async ({
   max_timeout_in_ms,
   fetchFn = fetch
 }: ClientArgs): Promise<QboClient> => {
-  const config = await getConfig({
+  const {
+    error: configError, data: config
+  } = await getConfig({
     fetchFn,
     use_sandbox: use_sandbox,
     access_token: access_token,
@@ -77,9 +80,14 @@ export const client = async ({
     realm_id: realm_id,
     max_timeout_in_ms: max_timeout_in_ms
   });
+  if (configError) {
+    throw configError;
+  }
   return {
     async refreshAccessToken() {
-      const refreshTokenResponse = await fetchFn(config.TOKEN_URL, {
+      const {
+        error: refreshTokenError, data: refreshTokenResponse
+      } = await fetchFn(config.TOKEN_URL, {
         method: "POST",
         headers: {
           Accept: "application/json",
@@ -93,16 +101,22 @@ export const client = async ({
         signal: getSignalForTimeout({ config })
       })
         .then(getJson<RefreshTokenResponse>())
-        .catch(recastAbortError);
+        .catch(handleQBOError);
+      if (refreshTokenError) {
+        return err(refreshTokenError);
+      }
       config.REFRESH_TOKEN = refreshTokenResponse.refresh_token;
       config.ACCESS_TOKEN = refreshTokenResponse.access_token;
+      return ok<void>();
     },
     async revokeAccess(tokenType: "REFRESH" | "ACCESS") {
       const token = tokenType === "REFRESH" ? config.REFRESH_TOKEN : config.ACCESS_TOKEN;
       if (!token) {
         throw new Error(`No ${tokenType} token found to revoke`);
       }
-      const res = await fetchFn(config.REVOKE_URL, {
+      const {
+        error: revokeError
+      } = await fetchFn(config.REVOKE_URL, {
         method: "POST",
         headers: {
           Accept: "application/json",
@@ -113,15 +127,18 @@ export const client = async ({
           token: token
         }),
         signal: getSignalForTimeout({ config })
-      }).catch(recastAbortError);
-      if (!res.ok) {
-        throw new Error(`Request failed with status code ${res.status}`);
+      })
+        .then(ok)
+        .catch(handleQBOError);
+      if (revokeError) {
+        return err(revokeError);
       }
       config.ACCESS_TOKEN = null;
       if (tokenType === "REFRESH") {
         config.REFRESH_TOKEN = null;
         config.REALM_ID = null;
       }
+      return ok<void>();
     },
     get tokens(): Tokens {
       const refreshToken = config.REFRESH_TOKEN;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,5 @@
 import { discovery, DiscoveryConfig } from "./discovery";
+import { withResult } from "ts-error-as-value";
 
 export interface Config extends DiscoveryConfig {
   REFRESH_TOKEN: string | null,
@@ -15,7 +16,7 @@ interface GetConfigArgs {
   max_timeout_in_ms?: number,
   fetchFn: typeof fetch
 }
-export const getConfig = async ({
+export const getConfig = withResult(async ({
   use_sandbox,
   access_token,
   refresh_token,
@@ -23,10 +24,10 @@ export const getConfig = async ({
   max_timeout_in_ms,
   fetchFn
 }: GetConfigArgs): Promise<Config> => ({
-  ...await discovery({ fetchFn, use_sandbox: use_sandbox }),
+  ...(await discovery({ fetchFn, use_sandbox: use_sandbox })).successOrThrow(),
   REFRESH_TOKEN: refresh_token as string | null,
   ACCESS_TOKEN: access_token as string | null,
   REALM_ID: realm_id as string | null,
   MAX_TIMEOUT_IN_MS: max_timeout_in_ms
-});
+}));
 

--- a/src/lib/errors/error-classes.ts
+++ b/src/lib/errors/error-classes.ts
@@ -1,0 +1,225 @@
+import { QBOApiErrorResponse } from "./index";
+
+export class QBOError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly name: string,
+    public readonly errorJson: QBOApiErrorResponse | null
+  ) {
+    super(message);
+  }
+}
+
+export class UnknownQBOError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 0, "Unknown", errorJson);
+  }
+}
+
+export class InvalidQueryArgsError extends QBOError {
+  constructor(message: string) {
+    super(message, 400, "InvalidQueryArgs", null);
+  }
+}
+
+export class BadRequestError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 400, "BadRequest", errorJson);
+  }
+}
+
+export class UnauthorizedError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 401, "Unauthorized", errorJson);
+  }
+}
+
+export class PaymentRequiredError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 402, "PaymentRequired", errorJson);
+  }
+}
+
+export class ForbiddenError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 403, "Forbidden", errorJson);
+  }
+}
+
+export class NotFoundError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 404, "NotFound", errorJson);
+  }
+}
+
+export class MethodNotAllowedError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 405, "MethodNotAllowed", errorJson);
+  }
+}
+
+export class NotAcceptableError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 406, "NotAcceptable", errorJson);
+  }
+}
+
+export class ProxyAuthenticationRequiredError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 407, "ProxyAuthenticationRequired", errorJson);
+  }
+}
+
+export class RequestTimeoutError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 408, "RequestTimeout", errorJson);
+  }
+}
+
+export class ConflictError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 409, "Conflict", errorJson);
+  }
+}
+
+export class GoneError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 410, "Gone", errorJson);
+  }
+}
+
+export class LengthRequiredError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 411, "LengthRequired", errorJson);
+  }
+}
+
+export class PreconditionFailedError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 412, "PreconditionFailed", errorJson);
+  }
+}
+
+export class PayloadTooLargeError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 413, "PayloadTooLarge", errorJson);
+  }
+}
+
+export class UnsupportedMediaTypeError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 415, "UnsupportedMediaType", errorJson);
+  }
+}
+
+export class UnprocessableEntityError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 422, "UnprocessableEntity", errorJson);
+  }
+}
+
+export class TooManyRequestsError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 429, "TooManyRequests", errorJson);
+  }
+}
+
+export class InternalServerError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 500, "InternalServerError", errorJson);
+  }
+}
+
+export class NotImplementedError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 501, "NotImplemented", errorJson);
+  }
+}
+
+export class BadGatewayError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 502, "BadGateway", errorJson);
+  }
+}
+
+export class ServiceUnavailableError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 503, "ServiceUnavailable", errorJson);
+  }
+}
+
+export class GatewayTimeoutError extends QBOError {
+  constructor(
+    message: string,
+    errorJson: QBOApiErrorResponse | null = null
+  ) {
+    super(message, 504, "GatewayTimeout", errorJson);
+  }
+}

--- a/src/lib/errors/index.ts
+++ b/src/lib/errors/index.ts
@@ -1,0 +1,87 @@
+import {
+  BadGatewayError,
+  BadRequestError, QBOError,
+  ConflictError,
+  ForbiddenError, GatewayTimeoutError,
+  GoneError, InternalServerError, LengthRequiredError,
+  MethodNotAllowedError,
+  NotAcceptableError,
+  NotFoundError, NotImplementedError, PayloadTooLargeError,
+  PaymentRequiredError, PreconditionFailedError,
+  ProxyAuthenticationRequiredError,
+  RequestTimeoutError, ServiceUnavailableError, TooManyRequestsError,
+  UnauthorizedError, UnprocessableEntityError, UnsupportedMediaTypeError, UnknownQBOError
+} from "./error-classes";
+
+export type QBOApiErrorResponse = {
+  Fault: {
+    Error: {
+      Message: string,
+      Detail: string,
+      code: string
+    }[],
+    type: string
+  },
+  time: string
+};
+export const getErrorFromResponse = async (
+  response: Response
+): Promise<QBOError> => {
+  if (response.ok) {
+    throw new Error(`Tried to get an error instance from response but there was no error (received status code ${response.status})`);
+  }
+  const message: string = `Error in QBO request to url ${response.url}`;
+  let errorJsonBody: QBOApiErrorResponse | null = null;
+  try {
+    errorJsonBody = await response.json();
+  } catch {}
+
+  switch (response.status) {
+    case 400:
+      return new BadRequestError(message, errorJsonBody);
+    case 401:
+      return new UnauthorizedError(message, errorJsonBody);
+    case 402:
+      return new PaymentRequiredError(message, errorJsonBody);
+    case 403:
+      return new ForbiddenError(message, errorJsonBody);
+    case 404:
+      return new NotFoundError(message, errorJsonBody);
+    case 405:
+      return new MethodNotAllowedError(message, errorJsonBody);
+    case 406:
+      return new NotAcceptableError(message, errorJsonBody);
+    case 407:
+      return new ProxyAuthenticationRequiredError(message, errorJsonBody);
+    case 408:
+      return new RequestTimeoutError(message, errorJsonBody);
+    case 409:
+      return new ConflictError(message, errorJsonBody);
+    case 410:
+      return new GoneError(message, errorJsonBody);
+    case 411:
+      return new LengthRequiredError(message, errorJsonBody);
+    case 412:
+      return new PreconditionFailedError(message, errorJsonBody);
+    case 413:
+      return new PayloadTooLargeError(message, errorJsonBody);
+    case 415:
+      return new UnsupportedMediaTypeError(message, errorJsonBody);
+    case 422:
+      return new UnprocessableEntityError(message, errorJsonBody);
+    case 429:
+      return new TooManyRequestsError(message, errorJsonBody);
+    case 500:
+      return new InternalServerError(message, errorJsonBody);
+    case 501:
+      return new NotImplementedError(message, errorJsonBody);
+    case 502:
+      return new BadGatewayError(message, errorJsonBody);
+    case 503:
+      return new ServiceUnavailableError(message, errorJsonBody);
+    case 504:
+      return new GatewayTimeoutError(message, errorJsonBody);
+    default:
+      return new UnknownQBOError(`Status of ${response.status} is not a known QBO error`, errorJsonBody);
+  }
+};

--- a/src/query.unit.test.ts
+++ b/src/query.unit.test.ts
@@ -1,7 +1,7 @@
 import { combine, fetchListQuery, optsToListQueryCondition, QueryOptsBase, QueryOptsInternal } from "./list";
 import { QBOQueryableEntityType, SnakeToCamelCase } from "./lib/types";
 import { Config } from "./lib/config";
-
+import "ts-error-as-value/lib/globals";
 
 describe("combine", () => {
   it("should correctly combine two QueryResponses", () => {
@@ -313,7 +313,7 @@ describe("fetchQuery", () => {
         Entity: "Employee",
         headers,
         fetchFn
-      })
+      }).then(result => result.successOrThrow())
     )).rejects.toThrowError();
 
     expect(fetchFn).toHaveBeenCalled();
@@ -342,14 +342,17 @@ describe("fetchQuery", () => {
       json: () => Promise.resolve(expectedData)
     }));
 
-    const result = await fetchListQuery({
+    const {
+      data: result, error
+    } = await fetchListQuery({
       config,
       opts,
       Entity: "Employee",
       headers,
       fetchFn
     });
-
+    
+    expect(error).toBeNull();
     expect(result).toEqual(expectedData);
   });
 
@@ -375,7 +378,9 @@ describe("fetchQuery", () => {
         json: () => Promise.resolve({ QueryResponse: { Employee: [] } })
       }));
 
-    const result = await fetchListQuery({
+    const {
+      data: result, error
+    } = await fetchListQuery({
       config,
       opts,
       Entity: "Employee",
@@ -383,6 +388,7 @@ describe("fetchQuery", () => {
       fetchFn
     });
 
+    expect(error).toBeNull();
     expect(result).toEqual(expectedData);
     expect(fetchFn).toHaveBeenCalledTimes(2);
   });
@@ -431,7 +437,9 @@ describe("fetchQuery", () => {
         json: () => Promise.resolve({ QueryResponse: { Employee: [{ Id: "3" }] } })
       }));
 
-    const result = await fetchListQuery({
+    const {
+      data: result, error
+    } = await fetchListQuery({
       config,
       opts,
       Entity: "Employee",
@@ -439,6 +447,7 @@ describe("fetchQuery", () => {
       fetchFn
     });
 
+    expect(error).toBeNull();
     expect(result).toEqual({ QueryResponse: { Employee: [{ Id: "1" }, { Id: "2" }, { Id: "3" }] } });
   });
 });

--- a/src/report.unit.test.ts
+++ b/src/report.unit.test.ts
@@ -1,6 +1,7 @@
 import { ReportQuery } from "./report-query";
 import { createReportOpts } from "./report";
 import { format } from "date-fns";
+import "ts-error-as-value/lib/globals";
 
 
 describe("createReportOpts", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -988,15 +988,6 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@es-joy/jsdoccomment@~0.31.0":
-  version "0.31.0"
-  resolved "https://registry.yarnpkg.com/@es-joy/jsdoccomment/-/jsdoccomment-0.31.0.tgz#dbc342cc38eb6878c12727985e693eaef34302bc"
-  integrity sha512-tc1/iuQcnaiSIUVad72PBierDFpsxdUHtEF/OrfqvM1CBAsIoMP51j52jTMb3dXriwhieTo289InzZj72jL3EQ==
-  dependencies:
-    comment-parser "1.3.1"
-    esquery "^1.4.0"
-    jsdoc-type-pratt-parser "~3.1.0"
-
 "@eslint/eslintrc@^1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-1.3.3.tgz#2b044ab39fdfa75b4688184f9e573ce3c5b0ff95"
@@ -1405,6 +1396,13 @@
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.12.tgz#6b2c510a7ad7039e98e7b8d3d6598f4359e5c080"
   integrity sha512-vt+kDhq/M2ayberEtJcIN/hxXy1Pk+59g2FV/ZQceeaTyCtCucjL2Q7FXlFjtWn4n15KCr1NE2lNNFhp0lEThw==
 
+"@types/date-fns@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@types/date-fns/-/date-fns-2.6.0.tgz#b062ca46562002909be0c63a6467ed173136acc1"
+  integrity sha512-9DSw2ZRzV0Tmpa6PHHJbMcZn79HHus+BBBohcOaDzkK/G3zMjDUDYjJIWBFLbkh+1+/IOS0A59BpQfdr37hASg==
+  dependencies:
+    date-fns "*"
+
 "@types/express-serve-static-core@^4.17.18":
   version "4.17.31"
   resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz#a1139efeab4e7323834bb0226e62ac019f474b2f"
@@ -1468,13 +1466,13 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-3.0.1.tgz#5f8f2bca0a5863cb69bc0b0acd88c96cb1d4ae10"
   integrity sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==
 
-"@types/node-fetch@^2.5.7":
-  version "2.6.4"
-  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.4.tgz#1bc3a26de814f6bf466b25aeb1473fa1afe6a660"
-  integrity sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==
+"@types/node-fetch@^2.6.11":
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/@types/node-fetch/-/node-fetch-2.6.11.tgz#9b39b78665dae0e82a08f02f4967d62c66f95d24"
+  integrity sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==
   dependencies:
     "@types/node" "*"
-    form-data "^3.0.0"
+    form-data "^4.0.0"
 
 "@types/node@*":
   version "18.11.0"
@@ -1992,11 +1990,6 @@ commander@^4.0.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
   integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
 
-comment-parser@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/comment-parser/-/comment-parser-1.3.1.tgz#3d7ea3adaf9345594aedee6563f422348f165c1b"
-  integrity sha512-B52sN2VNghyq5ofvUsqZjmk6YkihBX5vMSChmSK9v4ShjKf3Vk5Xcmgpw4o+iIgtrnM/u5FiMpz9VKb8lpBveA==
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -2032,6 +2025,11 @@ cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+date-fns@*:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-3.3.1.tgz#7581daca0892d139736697717a168afbb908cfed"
+  integrity sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==
 
 debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
@@ -2148,19 +2146,6 @@ eslint-config-prettier@^8.5.0:
   version "8.5.0"
   resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz#5a81680ec934beca02c7b1a61cf8ca34b66feab1"
   integrity sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==
-
-eslint-plugin-jsdoc@^39.3.6:
-  version "39.3.6"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-39.3.6.tgz#6ba29f32368d72a51335a3dc9ccd22ad0437665d"
-  integrity sha512-R6dZ4t83qPdMhIOGr7g2QII2pwCjYyKP+z0tPOfO1bbAbQyKC20Y2Rd6z1te86Lq3T7uM8bNo+VD9YFpE8HU/g==
-  dependencies:
-    "@es-joy/jsdoccomment" "~0.31.0"
-    comment-parser "1.3.1"
-    debug "^4.3.4"
-    escape-string-regexp "^4.0.0"
-    esquery "^1.4.0"
-    semver "^7.3.7"
-    spdx-expression-parse "^3.0.1"
 
 eslint-plugin-no-null@^1.0.2:
   version "1.0.2"
@@ -2417,10 +2402,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
 
-form-data@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
-  integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
@@ -3119,11 +3104,6 @@ js-yaml@^4.1.0:
   dependencies:
     argparse "^2.0.1"
 
-jsdoc-type-pratt-parser@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-3.1.0.tgz#a4a56bdc6e82e5865ffd9febc5b1a227ff28e67e"
-  integrity sha512-MgtD0ZiCDk9B+eI73BextfRrVQl0oyzRG8B2BjORts6jbunj4ScKPcyXGTbB6eXL4y9TzxCm6hyeLq/2ASzNdw==
-
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -3735,24 +3715,6 @@ source-map@^0.6.0, source-map@^0.6.1:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
-spdx-exceptions@^2.1.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz#3f28ce1a77a00372683eade4a433183527a2163d"
-  integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
-
-spdx-expression-parse@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
-  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
-  dependencies:
-    spdx-exceptions "^2.1.0"
-    spdx-license-ids "^3.0.0"
-
-spdx-license-ids@^3.0.0:
-  version "3.0.12"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz#69077835abe2710b65f03969898b6637b505a779"
-  integrity sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==
-
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -3865,6 +3827,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-error-as-value@^0.4.207:
+  version "0.4.207"
+  resolved "https://registry.yarnpkg.com/ts-error-as-value/-/ts-error-as-value-0.4.207.tgz#2423be47d545216a600bbffd15f85ec7c5245b23"
+  integrity sha512-//AQto0Z/WlJZKMcvghEUA4d3beHL2jdv+LDEbbthUUAlmp4JM+YyVABdo9TM2cTzlYwSQkexYuFoYomwyN0aA==
 
 ts-jest@^29.0.3:
   version "29.0.3"


### PR DESCRIPTION
Having the api methods return Result objects from `ts-error-as-value`

Also adding explicit Error type classes for better error handling for the consumer